### PR TITLE
only add githubname to payload if the action was trigger by a github user

### DIFF
--- a/index.js
+++ b/index.js
@@ -18,15 +18,16 @@ async function main() {
     const extraProperties = core.getInput("extra-properties");
 
     const data = {
-      user: {
-        githubName: payload.sender.login
-      },
       systemCode,
       environment,
       gitRepositoryName: payload.repository.full_name,
       changeMadeBySystem: "github",
       commit: payload.after,
     };
+
+    if (payload && payload.sender && payload.sender.login) {
+      data.user.githubName = payload.sender.login;
+    }
 
     if (extraProperties) {
       data.extraProperties = extraProperties;


### PR DESCRIPTION
actions can be triggered on a schedule (cron), if they are, then they have no github user in the payload

Right now if a scheduled workflow uses this action, the action throws this error:
>Error: Action failed with error TypeError: Cannot read property 'login' of undefined

https://github.com/Financial-Times/origami-navigation-data/runs/2466396458?check_suite_focus=true